### PR TITLE
Prevent image modification using rolling_ball

### DIFF
--- a/tutorial43_shading_correction_using_rolling_ball.py
+++ b/tutorial43_shading_correction_using_rolling_ball.py
@@ -52,9 +52,9 @@ from cv2_rolling_ball import subtract_background_rolling_ball
 from matplotlib import pyplot as plt
 
 img = cv2.imread("images/Particle_gradient.jpg", 0)
-
+img_rb=img.copy() ## Copy the image to prevent modifications on the original image
 radius=20
-final_img, background = subtract_background_rolling_ball(img, radius, light_background=True,
+final_img, background = subtract_background_rolling_ball(img_rb, radius, light_background=True,
                                      use_paraboloid=False, do_presmooth=True)
 
 
@@ -64,7 +64,7 @@ final_img, background = subtract_background_rolling_ball(img, radius, light_back
 clahe = cv2.createCLAHE(clipLimit=3, tileGridSize=(8,8))
 clahe_img = clahe.apply(final_img)
 
-#cv2.imshow("Original image", img)
+cv2.imshow("Original image", img)
 cv2.imshow("Background image", background)
 cv2.imshow("AFter background subtraction", final_img)
 cv2.imshow("After CLAHE", clahe_img)


### PR DESCRIPTION
Subtract_background_rolling_ball (line 57) seems to modify the original image that is used as an argument (even though a different object is created for the output). That is why plotting the original image (line 67) looks like the final image (line 69-70). This issue can also be seen in the YouTube tutorial 43 (min 6:40 - 7:30).

To solve this issue, a copy of the image is created, called image_rb (line 55). The copy of the image (image_rb) is used as an argument for subtract_background_rolling_ball (line 57)